### PR TITLE
fixed and simplified the build a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,8 @@ node_modules
 yarn-error.log
 **/.ipynb_checkpoints
 *.tsbuildinfo
+
+.idea
+*.iml
 .vscode
+

--- a/README.md
+++ b/README.md
@@ -37,16 +37,20 @@ If the community grows around this we can adopt a more regular public meeting.
 ## Development
 
 ```bash
-conda create -n jupyterlab-data-explorer -c conda-forge python=3.6
-conda activate jupyterlab-data-explorer
+// Get this repo and `cd` into it
+git clone https://github.com/jupyterlab/jupyterlab-data-explorer.git
+cd jupyterlab-data-explorer
 
+// Alternatively, you can set up this repo using `conda`
+// conda create -n jupyterlab-data-explorer -c conda-forge python=3.6
+// conda activate jupyterlab-data-explorer
+
+// Install Jupyterlab
 pip install --pre jupyterlab
-yarn
-yarn run build
 
+// Build and link the data explorer packages
+jlpm build:dev
 
-jupyter labextension link ./dataregistry --no-build
-jupyter labextension link ./dataregistry-extension
-
+// Run Jupyterlab
 jupyter lab
 ```

--- a/dataregistry-extension/package.json
+++ b/dataregistry-extension/package.json
@@ -2,6 +2,11 @@
   "name": "@jupyterlab/dataregistry-extension",
   "version": "0.7.1",
   "description": "Exposes the dataregistry to JupyterLab.",
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension"
+  ],
   "homepage": "https://github.com/jupyterlab/jupyterlab",
   "bugs": {
     "url": "https://github.com/jupyterlab/jupyterlab/issues"
@@ -28,15 +33,15 @@
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
-    "@jupyterlab/application": "1.0.0-rc.0",
-    "@jupyterlab/apputils": "1.0.0-rc.0",
-    "@jupyterlab/coreutils": "3.0.0-rc.0",
-    "@jupyterlab/csvviewer": "1.0.0-rc.0",
-    "@jupyterlab/docmanager": "1.0.0-rc.0",
-    "@jupyterlab/docregistry": "1.0.0-rc.0",
-    "@jupyterlab/filebrowser": "1.0.0-rc.0",
-    "@jupyterlab/notebook": "1.0.0-rc.0",
-    "@jupyterlab/rendermime": "1.0.0-rc.0",
+    "@jupyterlab/application": "~1.0.0",
+    "@jupyterlab/apputils": "~1.0.0",
+    "@jupyterlab/coreutils": "~3.0.0",
+    "@jupyterlab/csvviewer": "~1.0.0",
+    "@jupyterlab/docmanager": "~1.0.0",
+    "@jupyterlab/docregistry": "~1.0.0",
+    "@jupyterlab/filebrowser": "~1.0.0",
+    "@jupyterlab/notebook": "~1.0.0",
+    "@jupyterlab/rendermime": "~1.0.0",
     "@nteract/data-explorer": "7.0.1",
     "@phosphor/datagrid": "^0.1.10",
     "@phosphor/messaging": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   ],
   "scripts": {
     "build": "tsc --build dataregistry dataregistry-extension",
-    "build:watch": "yarn run build --watch"
+    "build:dev": "jlpm install && jlpm run build && jlpm run link",
+    "build:watch": "jlpm run build --watch",
+    "link": "jupyter labextension link dataregistry --no-build && jupyter labextension link dataregistry-extension",
+    "unlink": "jupyter labextension unlink dataregistry --no-build && jupyter labextension unlink dataregistry-extension"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,17 +361,17 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@jupyterlab/application@1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/application/-/application-1.0.0-rc.0.tgz#fbd76dff1da5cdd8db2107e0137e50f72cf5ec78"
-  integrity sha512-kd2eQ9aPLeM9j7p+HrHClZgZU36Xo8xGJJUvjSamfHehgl2H4NEZs9Hr4NyxQTivL2+CmJn5p+UfrZtN+/4qDg==
+"@jupyterlab/application@~1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/application/-/application-1.0.1.tgz#aac172235f30dec79c1047dda83b87718d3689ae"
+  integrity sha512-rcEIrcjWMukeM23GZ9WJYnS1+JPYCClyfM07qhyIbDIdm7afQs6oIFegeeuo/6Or/AJ+lYMpVAW9vTpLLQluKQ==
   dependencies:
-    "@jupyterlab/apputils" "^1.0.0-rc.0"
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/docregistry" "^1.0.0-rc.0"
-    "@jupyterlab/rendermime" "^1.0.0-rc.0"
-    "@jupyterlab/rendermime-interfaces" "^1.3.0-rc.0"
-    "@jupyterlab/services" "^4.0.0-rc.0"
+    "@jupyterlab/apputils" "^1.0.1"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/docregistry" "^1.0.1"
+    "@jupyterlab/rendermime" "^1.0.1"
+    "@jupyterlab/rendermime-interfaces" "^1.3.0"
+    "@jupyterlab/services" "^4.0.1"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/application" "^1.6.3"
     "@phosphor/commands" "^1.6.3"
@@ -383,14 +383,14 @@
     "@phosphor/widgets" "^1.8.0"
     font-awesome "~4.7.0"
 
-"@jupyterlab/apputils@1.0.0-rc.0", "@jupyterlab/apputils@^1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/apputils/-/apputils-1.0.0-rc.0.tgz#148b9175e9b2fa8bb91024a7cd308acb113b0f3f"
-  integrity sha512-zpKO7RJ+pUFzzkouMcyT8nJkqI+tyeZ1WMYCCTc7/tWEQl9F8zBVI7JhQbI2rmMWCSQHKDTWyifkJcgnuekKLQ==
+"@jupyterlab/apputils@^1.0.1", "@jupyterlab/apputils@~1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/apputils/-/apputils-1.0.1.tgz#66bf45b40953155869c24d849bda36098ab6b9c5"
+  integrity sha512-crY5PjndVrspFdo/k8JchaC+OU7aOYIXmYhcYGLD7uwt/G6CpZgHSEA/4YuoxulmL0mG9bu0GD19ARSROxISkQ==
   dependencies:
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/services" "^4.0.0-rc.0"
-    "@jupyterlab/ui-components" "^1.0.0-rc.0"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/services" "^4.0.1"
+    "@jupyterlab/ui-components" "^1.0.0"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/commands" "^1.6.3"
     "@phosphor/coreutils" "^1.3.1"
@@ -406,32 +406,32 @@
     react-dom "~16.8.4"
     sanitize-html "~1.20.1"
 
-"@jupyterlab/attachments@^1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/attachments/-/attachments-1.0.0-rc.0.tgz#1474b6ad01d8878596f74eaf7f9e65644d432d7b"
-  integrity sha512-m639TWk+b21vZ6CoCCUKiLYJg1OIGWGUC4htB31ONI0+fgLBFUUpye7d/PBFwSDWc23/Gn97TZczbqi82O4d0A==
+"@jupyterlab/attachments@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/attachments/-/attachments-1.0.1.tgz#31551d8d05abae93831a665a551af558e6af8556"
+  integrity sha512-h4QKtw+1AwfGpxUdhQEpZ+8D1e+wI4mrjHeiAOVEdMm9tffuPIWaQDCD+e5YSZI0/Ip/tkbe9BpFpiAxIXPp2w==
   dependencies:
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/observables" "^2.2.0-rc.0"
-    "@jupyterlab/rendermime" "^1.0.0-rc.0"
-    "@jupyterlab/rendermime-interfaces" "^1.3.0-rc.0"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/observables" "^2.2.0"
+    "@jupyterlab/rendermime" "^1.0.1"
+    "@jupyterlab/rendermime-interfaces" "^1.3.0"
     "@phosphor/disposable" "^1.2.0"
     "@phosphor/signaling" "^1.2.3"
 
-"@jupyterlab/cells@^1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/cells/-/cells-1.0.0-rc.0.tgz#378513e89daf0bf4d21e4e7ca9e2838a992e8797"
-  integrity sha512-5FsQaEsBXeHbC0+TYUfBb1ggjZL5TsZ4+WwaPb8ZwHqB4FRCSJE6HdrpNwPCJIhY6lVKQvfGtB/yGC825gGZBQ==
+"@jupyterlab/cells@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/cells/-/cells-1.0.1.tgz#f149998d9dea4005cda695caf7380a3b8be9a258"
+  integrity sha512-oFBa02G2VbY584v/m8lCck8UTa+Wz/q3MuNQ18YSD+QJMdBmKHkeC/oEpmLJgXEq4Fdd7StRis5YKhN97ans0g==
   dependencies:
-    "@jupyterlab/apputils" "^1.0.0-rc.0"
-    "@jupyterlab/attachments" "^1.0.0-rc.0"
-    "@jupyterlab/codeeditor" "^1.0.0-rc.0"
-    "@jupyterlab/codemirror" "^1.0.0-rc.0"
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/observables" "^2.2.0-rc.0"
-    "@jupyterlab/outputarea" "^1.0.0-rc.0"
-    "@jupyterlab/rendermime" "^1.0.0-rc.0"
-    "@jupyterlab/services" "^4.0.0-rc.0"
+    "@jupyterlab/apputils" "^1.0.1"
+    "@jupyterlab/attachments" "^1.0.1"
+    "@jupyterlab/codeeditor" "^1.0.0"
+    "@jupyterlab/codemirror" "^1.0.1"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/observables" "^2.2.0"
+    "@jupyterlab/outputarea" "^1.0.1"
+    "@jupyterlab/rendermime" "^1.0.1"
+    "@jupyterlab/services" "^4.0.1"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/messaging" "^1.2.3"
@@ -440,13 +440,13 @@
     "@phosphor/widgets" "^1.8.0"
     react "~16.8.4"
 
-"@jupyterlab/codeeditor@^1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/codeeditor/-/codeeditor-1.0.0-rc.0.tgz#d42670dd4d850e846b7baa28042fce9c8f95de01"
-  integrity sha512-9PVnHTS1NBS20aeby/o4QHxWCzrYrMYT4eVN2Am4oHoSUIEsfq3toQUy+eCSg8cZVnpYpo1uatZuFpQ8hQb57Q==
+"@jupyterlab/codeeditor@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/codeeditor/-/codeeditor-1.0.0.tgz#62fb62880330c83ecf0194ef91ec8302709f9c55"
+  integrity sha512-unv4RmDCXsWCW+ieL8je3X6sJValYQNVoHNWA1/RD6mOydh4G9sDmCZ6WM1DboG1OHnMr6pzz0HmA/jvA/JO1w==
   dependencies:
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/observables" "^2.2.0-rc.0"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/observables" "^2.2.0"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/disposable" "^1.2.0"
     "@phosphor/dragdrop" "^1.3.3"
@@ -454,16 +454,16 @@
     "@phosphor/signaling" "^1.2.3"
     "@phosphor/widgets" "^1.8.0"
 
-"@jupyterlab/codemirror@^1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/codemirror/-/codemirror-1.0.0-rc.0.tgz#4789363f802dce66c8e25b88d69ac5508962d484"
-  integrity sha512-MwUJBp/Y7KZeR8SsgLn7vVyWaNSAQXs1ELWPhaDUMQNzIJmYCzuUfgbuRWYcuvW3oGcczZPH5LM9vysa5v2B1g==
+"@jupyterlab/codemirror@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/codemirror/-/codemirror-1.0.1.tgz#c3b38905428bc7a47198657daf63e0a507e73ba8"
+  integrity sha512-v/ncOhVA9EgDRCIT0Ry5Ze1l8VsEtC+5ewKY2Oz1cUkvfwoEFcppFPQuUxHR8K7Ib9IsbVtM6L21dG4O1XGZrg==
   dependencies:
-    "@jupyterlab/apputils" "^1.0.0-rc.0"
-    "@jupyterlab/codeeditor" "^1.0.0-rc.0"
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/observables" "^2.2.0-rc.0"
-    "@jupyterlab/statusbar" "^1.0.0-rc.0"
+    "@jupyterlab/apputils" "^1.0.1"
+    "@jupyterlab/codeeditor" "^1.0.0"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/observables" "^2.2.0"
+    "@jupyterlab/statusbar" "^1.0.1"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/commands" "^1.6.3"
     "@phosphor/coreutils" "^1.3.1"
@@ -473,10 +473,10 @@
     codemirror "~5.47.0"
     react "~16.8.4"
 
-"@jupyterlab/coreutils@3.0.0-rc.0", "@jupyterlab/coreutils@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/coreutils/-/coreutils-3.0.0-rc.0.tgz#fbed9ac0c1064dbe5d09c25304688ed57cd7c13f"
-  integrity sha512-xMQw61Ev7+kEJPtwvXSVU28+w01AF33iwgxuslqx6uUaQBGOJWoPPrO5DBvjlDdHiS7kasAryJ2tTwvAVo5m2Q==
+"@jupyterlab/coreutils@^3.0.0", "@jupyterlab/coreutils@~3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/coreutils/-/coreutils-3.0.0.tgz#b636e2d478d7098ff12439de3cf4312edd945c09"
+  integrity sha512-l48G1qhff4CZpsxjje92S6caLUixzfDMAD5vjNZL9obexUAMF+344cpVWsm2r2CQROUW7bPB8wjAtFbp8nK/QQ==
   dependencies:
     "@phosphor/commands" "^1.6.3"
     "@phosphor/coreutils" "^1.3.1"
@@ -490,14 +490,14 @@
     path-posix "~1.0.0"
     url-parse "~1.4.3"
 
-"@jupyterlab/csvviewer@1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/csvviewer/-/csvviewer-1.0.0-rc.0.tgz#bd58b7bb2ec27d011581656a401a3af6cae39a45"
-  integrity sha512-KC+lXTaBbSzoyLbDMFQ5bX+pZgCSj7wXhREeKK313HuisjctHBpLQqIyyys9U2Ud4OxGWVFqEKfdDdY7z7ABfw==
+"@jupyterlab/csvviewer@~1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/csvviewer/-/csvviewer-1.0.1.tgz#608ed8dc3a73e17132e085d1697c93dfcc244953"
+  integrity sha512-SigWNlw7umavfiR46gWYopphlVODsJMdDZCHKIwVWKXs6SQdUJ60OAjvcbigQD4+/KfUvFb5Xmtp6rFh3YFe6g==
   dependencies:
-    "@jupyterlab/apputils" "^1.0.0-rc.0"
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/docregistry" "^1.0.0-rc.0"
+    "@jupyterlab/apputils" "^1.0.1"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/docregistry" "^1.0.1"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/datagrid" "^0.1.9"
@@ -506,16 +506,16 @@
     "@phosphor/signaling" "^1.2.3"
     "@phosphor/widgets" "^1.8.0"
 
-"@jupyterlab/docmanager@1.0.0-rc.0", "@jupyterlab/docmanager@^1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/docmanager/-/docmanager-1.0.0-rc.0.tgz#4c1f4ae8c4721157701876804cc2d3c1b3a5e2f6"
-  integrity sha512-9YOOjpXXTpegVGm8aFhZcDVjahrqCVm2gxbo+DJhv4mq54jFxx2XzwM9yMxVsOwKGo7OckAvEkL+Tc4iB9znzQ==
+"@jupyterlab/docmanager@^1.0.1", "@jupyterlab/docmanager@~1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/docmanager/-/docmanager-1.0.1.tgz#03201ff381be1bfe99e7626a1a6298c9e3bf56e8"
+  integrity sha512-Moj5MKL/8Zp1WfhkobwlGps/409OhyV2zYpxa+sC7q0DEszqYFYtLnZQMeGxLEo+9+jCCvcw8VBJtrl/qEJmXQ==
   dependencies:
-    "@jupyterlab/apputils" "^1.0.0-rc.0"
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/docregistry" "^1.0.0-rc.0"
-    "@jupyterlab/services" "^4.0.0-rc.0"
-    "@jupyterlab/statusbar" "^1.0.0-rc.0"
+    "@jupyterlab/apputils" "^1.0.1"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/docregistry" "^1.0.1"
+    "@jupyterlab/services" "^4.0.1"
+    "@jupyterlab/statusbar" "^1.0.1"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/disposable" "^1.2.0"
@@ -525,19 +525,19 @@
     "@phosphor/widgets" "^1.8.0"
     react "~16.8.4"
 
-"@jupyterlab/docregistry@1.0.0-rc.0", "@jupyterlab/docregistry@^1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/docregistry/-/docregistry-1.0.0-rc.0.tgz#603410cd7405b98fd545e3e796675b6c1ca3b310"
-  integrity sha512-Lh3vpOCfCBLRja5WOepjhpZ7sOlfDHEahis4Ilpok5iF71swvfs8J2dH293Wrxd/lF7GSd3xir4ATR43vDuGcw==
+"@jupyterlab/docregistry@^1.0.1", "@jupyterlab/docregistry@~1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/docregistry/-/docregistry-1.0.1.tgz#28ca14e7c43c161384d5582e011b0a70522bb8eb"
+  integrity sha512-2BXJl2SBGSXcPN0uLEAZJs2ZdGzXTjB6/NFO2UUjRf4Ixcj6OqqX+S4ys37Yag3/5csUabcrM+/vazRFqza5xQ==
   dependencies:
-    "@jupyterlab/apputils" "^1.0.0-rc.0"
-    "@jupyterlab/codeeditor" "^1.0.0-rc.0"
-    "@jupyterlab/codemirror" "^1.0.0-rc.0"
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/observables" "^2.2.0-rc.0"
-    "@jupyterlab/rendermime" "^1.0.0-rc.0"
-    "@jupyterlab/rendermime-interfaces" "^1.3.0-rc.0"
-    "@jupyterlab/services" "^4.0.0-rc.0"
+    "@jupyterlab/apputils" "^1.0.1"
+    "@jupyterlab/codeeditor" "^1.0.0"
+    "@jupyterlab/codemirror" "^1.0.1"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/observables" "^2.2.0"
+    "@jupyterlab/rendermime" "^1.0.1"
+    "@jupyterlab/rendermime-interfaces" "^1.3.0"
+    "@jupyterlab/services" "^4.0.1"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/disposable" "^1.2.0"
@@ -545,17 +545,17 @@
     "@phosphor/signaling" "^1.2.3"
     "@phosphor/widgets" "^1.8.0"
 
-"@jupyterlab/filebrowser@1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/filebrowser/-/filebrowser-1.0.0-rc.0.tgz#b7cfffb74bf455d2311bdc93141ff3447a91699a"
-  integrity sha512-6mTHw7okOT/oSs01qdCpYP3FApgTIjD1tbrLcEscDSeej7u95JzRC0UaQFPxFa5k2VMki1+eimmS87bf1OgDwQ==
+"@jupyterlab/filebrowser@~1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/filebrowser/-/filebrowser-1.0.1.tgz#dc2c11f6a02a84752c7255010b771ae98aa5db99"
+  integrity sha512-u6Ne3BP/NlhD4GGw9CgPPc48AwrZNGc31D/fy6cSOUE2APMpymFDE/dveAlxwCTeUsfUmltOH7AV9bsZX/0iag==
   dependencies:
-    "@jupyterlab/apputils" "^1.0.0-rc.0"
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/docmanager" "^1.0.0-rc.0"
-    "@jupyterlab/docregistry" "^1.0.0-rc.0"
-    "@jupyterlab/services" "^4.0.0-rc.0"
-    "@jupyterlab/statusbar" "^1.0.0-rc.0"
+    "@jupyterlab/apputils" "^1.0.1"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/docmanager" "^1.0.1"
+    "@jupyterlab/docregistry" "^1.0.1"
+    "@jupyterlab/services" "^4.0.1"
+    "@jupyterlab/statusbar" "^1.0.1"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/disposable" "^1.2.0"
@@ -566,21 +566,21 @@
     "@phosphor/widgets" "^1.8.0"
     react "~16.8.4"
 
-"@jupyterlab/notebook@1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/notebook/-/notebook-1.0.0-rc.0.tgz#ce7e5f58fd74c07c88f5a64601e6ba3028d6c087"
-  integrity sha512-uxf6HlyrnKXLE2VV6+gcN/AKAos0Fd0vC6G4Zmlep7VkNkuM7VTTFpHwB8/5h3V/pKkmukRgXjwF9U1Snyt+eQ==
+"@jupyterlab/notebook@~1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/notebook/-/notebook-1.0.1.tgz#0b7d9b2c728bcc12897c30c4259d19121b84fa4b"
+  integrity sha512-36xsJjggzhL7BYQLFEwJJg9y3nj39K85Edj9GmzWquspfoI6RnjTrcvVZsvpKE8+0yFlzb27RdMCgCek4/o7Bg==
   dependencies:
-    "@jupyterlab/apputils" "^1.0.0-rc.0"
-    "@jupyterlab/cells" "^1.0.0-rc.0"
-    "@jupyterlab/codeeditor" "^1.0.0-rc.0"
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/docregistry" "^1.0.0-rc.0"
-    "@jupyterlab/observables" "^2.2.0-rc.0"
-    "@jupyterlab/rendermime" "^1.0.0-rc.0"
-    "@jupyterlab/services" "^4.0.0-rc.0"
-    "@jupyterlab/statusbar" "^1.0.0-rc.0"
-    "@jupyterlab/ui-components" "^1.0.0-rc.0"
+    "@jupyterlab/apputils" "^1.0.1"
+    "@jupyterlab/cells" "^1.0.1"
+    "@jupyterlab/codeeditor" "^1.0.0"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/docregistry" "^1.0.1"
+    "@jupyterlab/observables" "^2.2.0"
+    "@jupyterlab/rendermime" "^1.0.1"
+    "@jupyterlab/services" "^4.0.1"
+    "@jupyterlab/statusbar" "^1.0.1"
+    "@jupyterlab/ui-components" "^1.0.0"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/domutils" "^1.1.3"
@@ -592,10 +592,10 @@
     "@phosphor/widgets" "^1.8.0"
     react "~16.8.4"
 
-"@jupyterlab/observables@^2.2.0-rc.0":
-  version "2.2.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/observables/-/observables-2.2.0-rc.0.tgz#0748e372f7a008fd933359d308608a038fbd8706"
-  integrity sha512-MYqbj1OUhMENTTaYWXoPfCf9oG+hj01Gbjio9WejmoMXBMcjyIomYkjpz7Q7YgdsXFDII8iGm0b7xOjGXbM8jw==
+"@jupyterlab/observables@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/observables/-/observables-2.2.0.tgz#be29c6cadad88c202e7963ace2410bbe7b101226"
+  integrity sha512-/oi7vl70yAX5QTXmZafyDSwU8fT1Oa/MdpDDYGkc5IklW0kU3NDqSoawfLovkdgGZvCOCM+6JQqUPRdhn8VZqg==
   dependencies:
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/coreutils" "^1.3.1"
@@ -603,17 +603,17 @@
     "@phosphor/messaging" "^1.2.3"
     "@phosphor/signaling" "^1.2.3"
 
-"@jupyterlab/outputarea@^1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/outputarea/-/outputarea-1.0.0-rc.0.tgz#f395484bf004e3d4ea4e8c5769d8662c008062f0"
-  integrity sha512-3CswZVnCSQm18Ovfree/xUu7hRTs/ShcwVl92P7XMfal7xJGhhBcs0Vj2S/mV/VDfH5BiTkgs1DTfDa1xlrifQ==
+"@jupyterlab/outputarea@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/outputarea/-/outputarea-1.0.1.tgz#1a9d5c53642d6bca1b224125b69b4e8cbcb2d788"
+  integrity sha512-6ZZXujp/E62DLfKhGj+gnN3k0OmaK4i+1SrY1sAUuevPRVgDflB37SE4slZiOXAT5wJE8WaedC+NhfJmZTbK8Q==
   dependencies:
-    "@jupyterlab/apputils" "^1.0.0-rc.0"
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/observables" "^2.2.0-rc.0"
-    "@jupyterlab/rendermime" "^1.0.0-rc.0"
-    "@jupyterlab/rendermime-interfaces" "^1.3.0-rc.0"
-    "@jupyterlab/services" "^4.0.0-rc.0"
+    "@jupyterlab/apputils" "^1.0.1"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/observables" "^2.2.0"
+    "@jupyterlab/rendermime" "^1.0.1"
+    "@jupyterlab/rendermime-interfaces" "^1.3.0"
+    "@jupyterlab/services" "^4.0.1"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/disposable" "^1.2.0"
@@ -621,25 +621,25 @@
     "@phosphor/signaling" "^1.2.3"
     "@phosphor/widgets" "^1.8.0"
 
-"@jupyterlab/rendermime-interfaces@^1.3.0-rc.0":
-  version "1.3.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.3.0-rc.0.tgz#3688d057f5d3133d2873d11c22762434934aa7f7"
-  integrity sha512-Hs0XL+QvmZqcPWF/Q0MnIWXkDZ7EVCxO8xPayfF/2Q99LJ5wAGSApvnTqab3wGYQQMasztxTmgO2JcvxUQ8Ptw==
+"@jupyterlab/rendermime-interfaces@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.3.0.tgz#1911f3da7fda38cb36c0771a02cb75a8af544502"
+  integrity sha512-04ohT/xdTcdp/TKuNMqY1MLwh7IWyjbMrQXiuwanE8xo52fIe6OIK0DENwc6VDMej1+8NVSU7rX42urLCex0sA==
   dependencies:
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/widgets" "^1.8.0"
 
-"@jupyterlab/rendermime@1.0.0-rc.0", "@jupyterlab/rendermime@^1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime/-/rendermime-1.0.0-rc.0.tgz#78e301b8d945895fa3f0bb66a84663a840c7b6f1"
-  integrity sha512-JPw+rUrnNoIw8a8b8sopu2b8U7kRrYsd+/H+8EW1iW1WN3EsL0dSZKgqlXFVPbCrV66KLT/NwNDCba+BjyZn3Q==
+"@jupyterlab/rendermime@^1.0.1", "@jupyterlab/rendermime@~1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime/-/rendermime-1.0.1.tgz#f5126b1a59c7daefb0b689ba7cd2f1192f7b7e8d"
+  integrity sha512-/ZwhIZ5nbv5AqMxZj6wTpZGfdqcBkVeHcQGAKvqD9MjICw+tlziE9M6kvzlkWZ3B8aW1kLas1fXDJTtQ0HCgbQ==
   dependencies:
-    "@jupyterlab/apputils" "^1.0.0-rc.0"
-    "@jupyterlab/codemirror" "^1.0.0-rc.0"
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/observables" "^2.2.0-rc.0"
-    "@jupyterlab/rendermime-interfaces" "^1.3.0-rc.0"
-    "@jupyterlab/services" "^4.0.0-rc.0"
+    "@jupyterlab/apputils" "^1.0.1"
+    "@jupyterlab/codemirror" "^1.0.1"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/observables" "^2.2.0"
+    "@jupyterlab/rendermime-interfaces" "^1.3.0"
+    "@jupyterlab/services" "^4.0.1"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/messaging" "^1.2.3"
@@ -648,13 +648,13 @@
     lodash.escape "^4.0.1"
     marked "0.6.2"
 
-"@jupyterlab/services@^4.0.0-rc.0":
-  version "4.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/services/-/services-4.0.0-rc.0.tgz#514777305aa84d5b490528fa9d8fd40a72452dd0"
-  integrity sha512-+4TzgY+X7RgRDlKohmCTkIthRM6jHnY4zcWHq9IeerYkZsTzaXoksJeKwdxsu8cymK/qGHqkTLOqTnsxr6eb5Q==
+"@jupyterlab/services@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/services/-/services-4.0.1.tgz#08a8b5c92ae45c095f84975c4bf99ee2407c3d16"
+  integrity sha512-gsErfZra65U3xh2jQu652/8mAb/LwAAYHVVybthTgZfh+ffWES04P80RDfq3nYBGIp8swXo/LFMKJEUGjaczyg==
   dependencies:
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/observables" "^2.2.0-rc.0"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/observables" "^2.2.0"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/disposable" "^1.2.0"
@@ -662,15 +662,15 @@
     node-fetch "^2.6.0"
     ws "^7.0.0"
 
-"@jupyterlab/statusbar@^1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/statusbar/-/statusbar-1.0.0-rc.0.tgz#f035307830f1d4cb5776d7c73444ca24840c0d38"
-  integrity sha512-diWSUv8JEI1NqQDohyzYF+Ym5Pcc04iTCdldHkSji+TB1G+u1y19Rq5RLvHAD/hg6VMDAgMuQoeOl6PqEc+NxQ==
+"@jupyterlab/statusbar@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/statusbar/-/statusbar-1.0.1.tgz#ac147e1e9cd6a16ee2d9e04aa5c43e2eb1b56872"
+  integrity sha512-cmE38ejzCaFDS5ikpHN8Ucu9YjYyXSX6omFlz9Xn3Z+ERTCBhhZ4cXYh+mKmyXPy6z5cJmHBGw9X5w7zxKEn0w==
   dependencies:
-    "@jupyterlab/apputils" "^1.0.0-rc.0"
-    "@jupyterlab/codeeditor" "^1.0.0-rc.0"
-    "@jupyterlab/coreutils" "^3.0.0-rc.0"
-    "@jupyterlab/services" "^4.0.0-rc.0"
+    "@jupyterlab/apputils" "^1.0.1"
+    "@jupyterlab/codeeditor" "^1.0.0"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/services" "^4.0.1"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/disposable" "^1.2.0"
@@ -680,10 +680,10 @@
     react "~16.8.4"
     typestyle "^2.0.1"
 
-"@jupyterlab/ui-components@^1.0.0-rc.0":
-  version "1.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/ui-components/-/ui-components-1.0.0-rc.0.tgz#1bfdcb5328ed6a67a55336f06124206ada06bc08"
-  integrity sha512-x/v2OwUx/5KItuHUFTtS26pCSlxY/4F8hil+ALIKU3qfodIBj01rCHNv+AV41SBDf1fn9ywVL/0I59K6gD7gPg==
+"@jupyterlab/ui-components@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/ui-components/-/ui-components-1.0.0.tgz#f82b00a68a24434ae56bee01d951aa4e087bb687"
+  integrity sha512-rR9I/wsznbuOj09gYvEWQo0fnze3ehK2dPWLY6ToE4k8qj9s39ViY48/jOoaQSaLLRaMD8M8B8ZWY0Cf+400bA==
   dependencies:
     "@blueprintjs/core" "^3.9.0"
     "@blueprintjs/icons" "^3.3.0"


### PR DESCRIPTION
I had a little bit of trouble getting this extension off the ground. The real issue was that a bunch of `@jupyterlab` dependencies were pegged at `1.0.0-rc0`, which I changed to `~1.0.0`. I then added a few new commands to `package.json` to simplify the build a bit. 

Also, I swapped some `yarn` commands for `jlpm`. It made sense to me to do so since the developer may not have a `yarn` command on their `$PATH` (eg I only have a `yarnpkg` command, to avoid a conflict with Hadoop `yarn`), and `jlpm` is guaranteed to be installed along with Jupyterlab itself.