### PR TITLE
Support caching all observables

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,10 @@ If the community grows around this we can adopt a more regular public meeting.
 ## Development
 
 ```bash
-// Get this repo and `cd` into it
 git clone https://github.com/jupyterlab/jupyterlab-data-explorer.git
 cd jupyterlab-data-explorer
 
-// Alternatively, you can set up this repo using `conda`
+// (optional) Create a fresh conda environment
 // conda create -n jupyterlab-data-explorer -c conda-forge python=3.6
 // conda activate jupyterlab-data-explorer
 

--- a/dataregistry-extension/package.json
+++ b/dataregistry-extension/package.json
@@ -15,10 +15,11 @@
   "author": "Project Jupyter",
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    "style.css"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "style": "style.css",
   "directories": {
     "lib": "lib/"
   },

--- a/dataregistry-extension/package.json
+++ b/dataregistry-extension/package.json
@@ -49,6 +49,7 @@
     "js-yaml": "3.12.2",
     "path": "0.12.7",
     "react": "16.8.4",
+    "react-inspector": "3.0.2",
     "rxjs": "6.5.2",
     "styled-components": "4.3.2"
   },

--- a/dataregistry-extension/src/active.ts
+++ b/dataregistry-extension/src/active.ts
@@ -11,7 +11,13 @@ import {
 import { DocumentWidget } from "@jupyterlab/docregistry";
 import { Widget } from "@phosphor/widgets";
 import { BehaviorSubject } from "rxjs";
-import { URL_, Registry, nestedDataType } from "@jupyterlab/dataregistry";
+import {
+  URL_,
+  Registry,
+  nestedDataType,
+  createConverter,
+  resolveDataType
+} from "@jupyterlab/dataregistry";
 import { hasURL_ } from "./widgets";
 import { Token } from "@phosphor/coreutils";
 import { RegistryToken } from "./registry";
@@ -42,11 +48,16 @@ function activate(
   const active = new BehaviorSubject<URL_ | null>(null);
 
   // Show active datasets in explorerr
-  registry.addDatasets(
-    nestedDataType.createDatasets(
-      ACTIVE_URL,
-      active.pipe(map(url => (url ? new Set([url]) : new Set())))
-    )
+  registry.addConverter(
+    createConverter({ from: resolveDataType }, ({ url }) => {
+      if (url.toString() !== ACTIVE_URL) {
+        return null;
+      }
+      return {
+        type: nestedDataType.createMimeType(),
+        data: active.pipe(map(url => (url ? new Set([url]) : new Set())))
+      };
+    })
   );
 
   // Track active documents open.

--- a/dataregistry-extension/src/csvviewer.ts
+++ b/dataregistry-extension/src/csvviewer.ts
@@ -4,7 +4,11 @@ import {
   JupyterFrontEndPlugin,
   JupyterFrontEnd
 } from "@jupyterlab/application";
-import { Registry, DataTypeNoArgs } from "@jupyterlab/dataregistry";
+import {
+  Registry,
+  DataTypeNoArgs,
+  createConverter
+} from "@jupyterlab/dataregistry";
 import { widgetDataType } from "./widgets";
 import { Observable, Subscription } from "rxjs";
 import { RegistryToken } from "./registry";
@@ -12,33 +16,27 @@ import { Message } from "@phosphor/messaging";
 
 export const CSVDataType = new DataTypeNoArgs<Observable<string>>("text/csv");
 
-const CSVConverter = CSVDataType.createSingleTypedConverter(
-  widgetDataType,
-  () => [
-    "Grid",
-    data$ => {
-      const grid = new (class MyDataGrid extends DataGrid {
-        onBeforeAttach(msg: Message) {
-          this._subscription = data$.subscribe(data => {
-            if (this.model) {
-              (this.model as DSVModel).dispose();
-            }
-            this.model = new DSVModel({ data, delimiter: "," });
-          });
-          super.onBeforeAttach(msg);
-        }
+class MyDataGrid extends DataGrid {
+  constructor(private _data: Observable<string>) {
+    super();
+    this.headerVisibility = "all";
+  }
+  onBeforeAttach(msg: Message) {
+    this._subscription = this._data.subscribe(data => {
+      if (this.model) {
+        (this.model as DSVModel).dispose();
+      }
+      this.model = new DSVModel({ data, delimiter: "," });
+    });
+    super.onBeforeAttach(msg);
+  }
 
-        onBeforeDetach(msg: Message) {
-          this._subscription && this._subscription.unsubscribe();
-          super.onBeforeDetach(msg);
-        }
-        private _subscription?: Subscription;
-      })();
-      grid.headerVisibility = "all";
-      return grid;
-    }
-  ]
-);
+  onBeforeDetach(msg: Message) {
+    this._subscription && this._subscription.unsubscribe();
+    super.onBeforeDetach(msg);
+  }
+  private _subscription?: Subscription;
+}
 
 const id = "@jupyterlab/dataregistry-extension:csv-viewer";
 
@@ -50,5 +48,10 @@ export default {
 } as JupyterFrontEndPlugin<void>;
 
 function activate(app: JupyterFrontEnd, registry: Registry): void {
-  registry.addConverter(CSVConverter);
+  registry.addConverter(
+    createConverter({ from: CSVDataType, to: widgetDataType }, ({ data }) => ({
+      type: "Grid",
+      data: new MyDataGrid(data)
+    }))
+  );
 }

--- a/dataregistry-extension/src/debugger.tsx
+++ b/dataregistry-extension/src/debugger.tsx
@@ -9,7 +9,13 @@ import {
   ILayoutRestorer
 } from "@jupyterlab/application";
 
-// import { Inspector } from "react-inspector";
+// Need to set global regenerator runtime, since react-inspector
+// is built with it.
+const regeneratorRuntime = require("regenerator-runtime");
+
+(window as any).regeneratorRuntime = regeneratorRuntime;
+
+import { Inspector } from "react-inspector";
 import {
   ReactWidget,
   ICommandPalette,
@@ -48,11 +54,11 @@ function Data({ data }: { data: unknown }) {
   if (data instanceof CachedObservable) {
     return (
       <UseBehaviorSubject subject={data.state}>
-        {data_ => <pre>{String(data_)}</pre>}
+        {data_ => <Inspector data={data_} />}
       </UseBehaviorSubject>
     );
   }
-  return <pre>{String(data)}</pre>;
+  return <Inspector data={data} />;
 }
 
 function Debugger({ registry }: { registry: Registry }) {

--- a/dataregistry-extension/src/debugger.tsx
+++ b/dataregistry-extension/src/debugger.tsx
@@ -9,6 +9,7 @@ import {
   ILayoutRestorer
 } from "@jupyterlab/application";
 
+import { Inspector } from "react-inspector";
 import {
   ReactWidget,
   ICommandPalette,
@@ -18,10 +19,21 @@ import {
 
 import * as React from "react";
 import { RegistryToken } from "./registry";
-import { Registry } from "@jupyterlab/dataregistry";
+import { Registry, CachedObservable } from "@jupyterlab/dataregistry";
 import { UseBehaviorSubject } from "./utils";
 
 const id = "@jupyterlab/dataregistry-extension:data-debugger";
+
+function Data({ data }: { data: unknown }) {
+  if (data instanceof CachedObservable) {
+    return (
+      <UseBehaviorSubject subject={data.value}>
+        {data_ => <Inspector data={data_} />}
+      </UseBehaviorSubject>
+    );
+  }
+  return <Inspector data={data} />;
+}
 
 function Debugger({ registry }: { registry: Registry }) {
   return (
@@ -33,11 +45,14 @@ function Debugger({ registry }: { registry: Registry }) {
               <li key={url}>
                 <code>{url}</code>
                 <ol style={{ listStyle: "none" }}>
-                  {[...registry.getURL(url).keys()].sort().map(mimeType => (
-                    <li key={mimeType}>
-                      <code>{mimeType}</code>
-                    </li>
-                  ))}
+                  {[...registry.getURL(url).entries()].map(
+                    ([mimeType, [cost, data]]) => (
+                      <li key={mimeType}>
+                        <code>{mimeType}</code>
+                        <Data data={data} />
+                      </li>
+                    )
+                  )}
                 </ol>
               </li>
             ))

--- a/dataregistry-extension/src/folders.tsx
+++ b/dataregistry-extension/src/folders.tsx
@@ -24,8 +24,8 @@ function activate(
   registry: Registry,
   fileBrowserFactory: IFileBrowserFactory
 ) {
-  registry.addConverter(folderDatasetsConverter);
   registry.addConverter(
+    folderDatasetsConverter,
     // Inspired by filebrowser.model.FileBrowserModel._handleContents
     createFolderConverter(
       async path =>

--- a/dataregistry-extension/src/notebooks.ts
+++ b/dataregistry-extension/src/notebooks.ts
@@ -220,10 +220,7 @@ function createOutputConverter(
 
       const data = defer(() =>
         outputsDataType.getDataset(registry.getURL(cellURL)).pipe(
-          map(outputs => {
-            console.log(outputs, outputID);
-            return outputs[outputID].data;
-          })
+          map(outputs => outputs[outputID].data)
         )
       );
       return { data, type: undefined };

--- a/dataregistry-extension/src/react-inspector.ts
+++ b/dataregistry-extension/src/react-inspector.ts
@@ -1,0 +1,1 @@
+declare module 'react-inspector';

--- a/dataregistry-extension/src/tableData.tsx
+++ b/dataregistry-extension/src/tableData.tsx
@@ -4,7 +4,11 @@
 |----------------------------------------------------------------------------*/
 
 import { JupyterFrontEndPlugin } from "@jupyterlab/application";
-import { DataTypeNoArgs, Registry } from "@jupyterlab/dataregistry";
+import {
+  DataTypeNoArgs,
+  Registry,
+  createConverter
+} from "@jupyterlab/dataregistry";
 
 import NteractDataExplorer, { Props } from "@nteract/data-explorer";
 import * as React from "react";
@@ -27,12 +31,12 @@ export const TableDataType = new DataTypeNoArgs<Observable<Props["data"]>>(
  *
  * https://github.com/nteract/nteract/tree/master/packages/data-explorer
  */
-const nteractDataExplorerConverter = TableDataType.createSingleTypedConverter(
-  reactDataType,
-  () => [
-    "nteract Data Explorer",
-    data$ => (
-      <UseObservable observable={data$} initial={undefined}>
+const nteractDataExplorerConverter = createConverter(
+  { from: TableDataType, to: reactDataType },
+  ({ data }) => ({
+    type: "nteract Data Explorer",
+    data: (
+      <UseObservable observable={data} initial={undefined}>
         {data =>
           data ? (
             <NteractDataExplorer
@@ -47,7 +51,7 @@ const nteractDataExplorerConverter = TableDataType.createSingleTypedConverter(
         }
       </UseObservable>
     )
-  ]
+  })
 );
 
 export default {

--- a/dataregistry-extension/style.css
+++ b/dataregistry-extension/style.css
@@ -1,0 +1,3 @@
+.scrollable {
+    overflow: scroll;
+}

--- a/dataregistry/src/converters.ts
+++ b/dataregistry/src/converters.ts
@@ -1,8 +1,4 @@
-import { Cost, Dataset, MimeType_, URL_, Data } from "./datasets";
-import { mergeMaps } from "./utils";
-
-export type Convert<T, V> = (data: T) => V;
-export type Converts<T, V> = Map<MimeType_, Convert<T, V>>;
+import { Cost, Dataset, MimeType_, URL_ } from "./datasets";
 
 /**
  * Function that can possibly convert between data type T to
@@ -10,35 +6,35 @@ export type Converts<T, V> = Map<MimeType_, Convert<T, V>>;
  *
  * It determines if it is able to convert T, based on it's mimetype
  * and returns a mapping of possible resulting mimetypes and
- * a function to compute their data.
- *
- * Mimetype comes before url because url is often not needed.
+ * resulting data.
  */
-export type Converter<T, V> = (
-  mimeType: MimeType_,
-  url: URL_
-) => Converts<T, V>;
+export type Converter<T, U> = (dataset: {
+  url: URL_;
+  mimeType: MimeType_;
+  cost: Cost;
+  data: T;
+}) => Array<{ mimeType: MimeType_; cost: Cost; data: U }>;
 
 /**
  * Applies the converter to a dataset iteratively until all mimetypes are filled out.
  *
  * Uses an implementation of Dijkstra's algorithm.
  */
-export function applyConverterDataset(
+export function applyConverterDataset<T>(
   url: URL_,
-  dataset: Dataset,
-  converter: Converter<any, any>
-): Dataset {
+  dataset: Dataset<T>,
+  converter: Converter<T, T>
+): Dataset<T> {
   // mimeTypes that we still need to convert
-  const toProcess: Array<[MimeType_, Cost, Data]> = [...dataset].map(
-    ([mimeType, [cost, data$]]) => [mimeType, cost, data$]
-  );
+  let toProcess: Array<{ mimeType: MimeType_; cost: Cost; data: T }> = [
+    ...dataset
+  ].map(([mimeType, [cost, data]]) => ({ mimeType, cost, data }));
   // processed mimetypes
-  const processed: Dataset = new Map();
+  const processed: Dataset<T> = new Map();
   // We should only process each mimeType once. They will start on the toProcess map
   // and then move to the processed.
   while (toProcess.length !== 0) {
-    const [mimeType, cost, data] = toProcess.pop()!;
+    const { mimeType, cost, data } = toProcess.pop()!;
 
     // If we already have this mimetype at a lower or equal cost, skip processing it.
     if (processed.has(mimeType) && processed.get(mimeType)![0] <= cost) {
@@ -48,38 +44,14 @@ export function applyConverterDataset(
     processed.set(mimeType, [cost, data]);
 
     // Iterate through its possible conversions and add
-    for (const [newMimeType, dataCreator] of converter(mimeType, url)) {
-      toProcess.push([newMimeType, cost + 1, dataCreator(data)]);
-    }
+    toProcess = toProcess.concat(converter({ cost, data, mimeType, url }));
   }
   return processed;
 }
 
-export function combineManyConverters<T, V>(
-  ...converters: Array<Converter<T, V>>
-): Converter<T, V> {
-  return (mimeType: MimeType_, url: URL_) => {
-    return mergeMaps(
-      // Just choose left one by default
-      xData => xData,
-      ...converters.map(c => c(mimeType, url))
-    );
-  };
-}
-
-export type SingleConvert<T, V> = null | [MimeType_, Convert<T, V>];
-
-/**
- * Helper function to create a creator that has either 0 or 1 resulting mimetypes.
- */
-export function singleConverter<T, V>(
-  fn: (mimeType: MimeType_, url: URL_) => SingleConvert<T, V>
-): Converter<T, V> {
-  return (mimeType, url) => {
-    const possibleResult = fn(mimeType, url);
-    if (possibleResult === null) {
-      return new Map();
-    }
-    return new Map([possibleResult]);
-  };
+export function combineManyConverters<T, U>(
+  ...converters: Array<Converter<T, U>>
+): Converter<T, U> {
+  return dataset =>
+    converters.map(c => c(dataset)).reduce((l, r) => l.concat(r), []);
 }

--- a/dataregistry/src/datasets.ts
+++ b/dataregistry/src/datasets.ts
@@ -1,10 +1,10 @@
 /**
  * A dataset is the core concept in the data registry. Conceptually,
- * it is a tuple of (url, MimeType, Cost, Data). Here are some examples:
+ * it is a tuple of (URL, MimeType, Cost, Data). Here are some examples:
  *
  * ```typescript
  * ["http://some-server/data.csv", "text/csv", 1, "cows,sheap,hands\n10,..."]
- * ["file://Analysis.ipynb#some-dataset", "application/vnd.dataresource+json", 0, {"data": [{"cows": ...}]})
+ * ["file:///Analysis.ipynb#some-dataset", "application/vnd.dataresource+json", 0, {"data": [{"cows": ...}]})
  * ```
  *
  * The way to think about this is that the url is the unique ID to refer to the dataset. Whereas
@@ -34,9 +34,6 @@
  * the data itself can all change over time.
  */
 
-import { Observable } from "rxjs";
-import { mergeMaps } from "./utils";
-
 /**
  * Unique ID. We use a string here instead of the builtin URL class because
  * we are using them as map keys and URLs are not equal based on their contents.
@@ -48,19 +45,17 @@ export type MimeType_ = string;
  * Cost should be >= 0
  */
 export type Cost = number;
-export type Data = unknown;
 
-export type DataValue = [Cost, Data];
-export type Dataset = Map<MimeType_, DataValue>;
+export type DataValue<T> = [Cost, T];
+export type Dataset<T> = Map<MimeType_, DataValue<T>>;
 
-export type Datasets = Map<URL_, Dataset>;
-export type Datasets$ = Observable<Datasets>;
+export type Datasets<T> = Map<URL_, Dataset<T>>;
 
 /**
  * Merges datasets, choosing the data with lower cost if there are conflicts.
  */
-export function mergeDataset(...datasets: Array<Dataset>): Dataset {
-  const merged: Dataset = new Map();
+export function mergeDataset<T>(...datasets: Array<Dataset<T>>): Dataset<T> {
+  const merged: Dataset<T> = new Map();
   for (const dataset of datasets) {
     for (const [mimeType, newValue] of dataset) {
       const oldValue = merged.get(mimeType);
@@ -72,36 +67,35 @@ export function mergeDataset(...datasets: Array<Dataset>): Dataset {
   return merged;
 }
 
-export function mergeDatasets(...datasets: Array<Datasets>): Datasets {
-  return mergeMaps(mergeDataset, ...datasets);
+export function createDataset<T>(mimeType: MimeType_, data: T): Dataset<T> {
+  return new Map([[mimeType, [0, data]]]);
 }
 
-export function createDataset(mimeType: MimeType_, data: Data): Dataset {
-  return new Map([[mimeType, [0, data] as [Cost, Data]]]);
-}
-
-export function createDatasets(
+export function createDatasets<T>(
   url: URL_,
   mimeType: MimeType_,
-  data: Data
-): Datasets {
+  data: T
+): Datasets<T> {
   return new Map([[url, createDataset(mimeType, data)]]);
 }
 
-export function getURLs(datasets: Datasets): Set<URL_> {
+export function getURLs(datasets: Datasets<any>): Set<URL_> {
   return new Set(datasets.keys());
 }
 
-export function getMimeTypes(datasets: Datasets, url: URL_): Set<MimeType_> {
+export function getMimeTypes(
+  datasets: Datasets<any>,
+  url: URL_
+): Set<MimeType_> {
   const dataset = datasets.get(url);
   return new Set(dataset && [...dataset.keys()]);
 }
 
-export function getData(
-  datasets: Datasets,
+export function getData<T>(
+  datasets: Datasets<T>,
   url: URL_,
   mimeType: MimeType_
-): Data | null {
+): T | null {
   const dataset = datasets.get(url);
   if (!dataset) {
     return null;

--- a/dataregistry/src/index.test.ts
+++ b/dataregistry/src/index.test.ts
@@ -51,10 +51,15 @@ test("Adding a converter gives the new mimetype", () => {
 
   r.addDatasets(createDatasets(url, initialMimeType, initialData));
 
-  const converter: Converter<string, string> = (mimeType, url) =>
+  const converter: Converter<string, string> = ({
+    mimeType,
+    url,
+    data,
+    cost
+  }) =>
     mimeType === initialMimeType
-      ? new Map([[convertedMimeType, data => dataConverter(url, data)]])
-      : new Map();
+      ? [{ mimeType: convertedMimeType, data: dataConverter(url, data), cost }]
+      : [];
 
   r.addConverter(converter);
 

--- a/dataregistry/src/registry.ts
+++ b/dataregistry/src/registry.ts
@@ -18,7 +18,7 @@ export class Registry {
   /**
    * Returns the dataset for a URL.
    */
-  getURL(url: URL_): Dataset {
+  getURL(url: URL_): Dataset<unknown> {
     if (this._datasets.has(url)) {
       return this._datasets.get(url)!;
     }
@@ -42,14 +42,15 @@ export class Registry {
     this._converters.add(converter);
   }
 
-  addDatasets(datasets: Datasets): void {
-    this._converters.add(
-      (_mimeType, url) =>
-        new Map(
-          [...(datasets.get(url) || (new Map() as Dataset))].map(
-            ([mimeType, [cost, data]]) => [mimeType, () => data]
-          )
-        )
+  addDatasets(datasets: Datasets<any>): void {
+    this._converters.add(({ mimeType, url }) =>
+      mimeType == resolveDataType.createMimeType() && datasets.has(url)
+        ? [...datasets.get(url)!.entries()].map(([mimeType, [cost, data]]) => ({
+            mimeType,
+            cost,
+            data
+          }))
+        : []
     );
   }
 
@@ -57,6 +58,6 @@ export class Registry {
     return combineManyConverters(...this._converters);
   }
 
-  private readonly _datasets: Datasets = new Map();
+  private readonly _datasets: Datasets<unknown> = new Map();
   private readonly _converters: Set<Converter<any, any>> = new Set();
 }

--- a/dataregistry/src/registry.ts
+++ b/dataregistry/src/registry.ts
@@ -38,8 +38,8 @@ export class Registry {
   /**
    * Adds a new converter.
    */
-  addConverter(converter: Converter<any, any>): void {
-    this._converters.add(converter);
+  addConverter(...converters: Array<Converter<any, any>>): void {
+    converters.forEach(converter => this._converters.add(converter));
   }
 
   addDatasets(datasets: Datasets<any>): void {

--- a/dataregistry/src/utils.ts
+++ b/dataregistry/src/utils.ts
@@ -92,13 +92,26 @@ const INITIAL_STATE: ObservableState<any> = {
  * If at any time, it has no subscribers, it will unsubscribe from its source.
  *
  * Why use this over the `refCount` operator? Well we store the last value on the object for easier debugging and introspection.
+ * 
+ * States:
+ *  1. Not subscribed yet
+ *  2. Subscribed and waiting for final state
+ *  3. In final state, unsubscribed
+ * 
+ * New subscriber:
+ * 1. If in state 1, then subscribe, move to state 2
+ * 2. if in state 2 or 3, return last value if it exists and final state, if it exists
+ * 
+ * Unsubscribe:
+ * 1. Should never be in state one when unsubscribing
+ * 2. if this is last subscription, unsubscribe from parent  
  */
 export class CachedObservable<T> extends Observable<T> {
   constructor(from: Observable<T>) {
     super(subscriber => {
       this._subscribers.add(subscriber);
       const state = this.state.value;
-      if (state.subscription === NOT_SUBSCRIBED) {
+      if (state.subscription === NOT_SUBSCRIBED && state.final === NOT_FINAL) {
         this._setState({
           subscription: from.subscribe(
             v => {
@@ -135,7 +148,7 @@ export class CachedObservable<T> extends Observable<T> {
           currentState.subscription !== NOT_SUBSCRIBED
         ) {
           currentState.subscription.unsubscribe();
-          this.state.next(INITIAL_STATE);
+          this._setState({subscription: NOT_SUBSCRIBED});
         }
       };
     });

--- a/dataregistry/src/utils.ts
+++ b/dataregistry/src/utils.ts
@@ -92,19 +92,19 @@ const INITIAL_STATE: ObservableState<any> = {
  * If at any time, it has no subscribers, it will unsubscribe from its source.
  *
  * Why use this over the `refCount` operator? Well we store the last value on the object for easier debugging and introspection.
- * 
+ *
  * States:
  *  1. Not subscribed yet
  *  2. Subscribed and waiting for final state
  *  3. In final state, unsubscribed
- * 
+ *
  * New subscriber:
  * 1. If in state 1, then subscribe, move to state 2
  * 2. if in state 2 or 3, return last value if it exists and final state, if it exists
- * 
+ *
  * Unsubscribe:
  * 1. Should never be in state one when unsubscribing
- * 2. if this is last subscription, unsubscribe from parent  
+ * 2. if this is last subscription, unsubscribe from parent
  */
 export class CachedObservable<T> extends Observable<T> {
   constructor(from: Observable<T>) {
@@ -148,7 +148,14 @@ export class CachedObservable<T> extends Observable<T> {
           currentState.subscription !== NOT_SUBSCRIBED
         ) {
           currentState.subscription.unsubscribe();
-          this._setState({subscription: NOT_SUBSCRIBED});
+
+          // If we haven't finished yet, reset the value and subscription
+          if (currentState.final === NOT_FINAL) {
+            this._setState({ subscription: NOT_SUBSCRIBED, value: NO_VALUE });
+          } else {
+            // Otherwise, just reset the subscription, keeping the the last value and final status
+            this._setState({ subscription: NOT_SUBSCRIBED });
+          }
         }
       };
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2547,6 +2547,14 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
+is-dom@^1.0.9:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-dom/-/is-dom-1.1.0.tgz#af1fced292742443bb59ca3f76ab5e80907b4e8a"
+  integrity sha512-u82f6mvhYxRPKpw8V1N0W8ce1xXwOrQtgGcxl6UCL5zBmZu3is/18K0rR7uFCnMDuAsS/3W54mGL4vsaFUQlEQ==
+  dependencies:
+    is-object "^1.0.1"
+    is-window "^1.0.2"
+
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -2583,6 +2591,11 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+  integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
+
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -2618,6 +2631,11 @@ is-what@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.2.3.tgz#50f76f1bd8e56967e15765d1d34302513701997b"
   integrity sha512-c4syLgFnjXTH5qd82Fp/qtUIeM0wA69xbI0KH1QpurMIvDaZFrS8UtAa4U52Dc2qSznaMxHit0gErMp6A/Qk1w==
+
+is-window@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-window/-/is-window-1.0.2.tgz#2c896ca53db97de45d3c33133a65d8c9f563480d"
+  integrity sha1-LIlspT25feRdPDMTOmXYyfVjSA0=
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -4132,6 +4150,15 @@ react-hot-loader@^4.1.2:
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.0.2"
     source-map "^0.7.3"
+
+react-inspector@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-3.0.2.tgz#c530a06101f562475537e47df428e1d7aff16ed8"
+  integrity sha512-PSR8xDoGFN8R3LKmq1NT+hBBwhxjd9Qwz8yKY+5NXY/CHpxXHm01CVabxzI7zFwFav/M3JoC/Z0Ro2kSX6Ef2Q==
+  dependencies:
+    babel-runtime "^6.26.0"
+    is-dom "^1.0.9"
+    prop-types "^15.6.1"
 
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.8.6"


### PR DESCRIPTION
This refactors how we define conversions, so that we can automatically cache all values produced by observables. It also shows the current value in the debugger, fixing https://github.com/jupyterlab/jupyterlab-data-explorer/issues/36