### PR TITLE
Make the browse UI scrollable

### DIFF
--- a/dataregistry-extension/src/browser.tsx
+++ b/dataregistry-extension/src/browser.tsx
@@ -64,7 +64,7 @@ function Browser({
   }, [active, follow]);
 
   return (
-    <div style={{ height: "100%" }}>
+    <div style={{ height: "100%", display: "flex", flexFlow: "column" }}>
       <select value={label} onChange={event => setLabel(event.target.value)}>
         {widgetLabels.map(label => (
           <option key={label} value={label}>

--- a/dataregistry-extension/src/utils.tsx
+++ b/dataregistry-extension/src/utils.tsx
@@ -58,5 +58,5 @@ export function PhosphorWidget({ widget }: { widget: Widget }) {
     return () => Widget.detach(widget);
   }, [widget]);
 
-  return <div style={{ height: "100%" }} ref={el} />;
+  return <div style={{ height: "100%" }} className="scrollable" ref={el} />;
 }


### PR DESCRIPTION


Previously you were not able to scroll on data  viewers that were larger than the browse  UI, like the [linked data viewer](https://github.com/jupyterlab/jupyterlab-metadata-service/),  now you are able to:

<img width="962" alt="Screen Shot 2019-08-29 at 3 56 58 PM" src="https://user-images.githubusercontent.com/1186124/63972034-df6da500-ca75-11e9-8af9-799d01fc2578.png">
