### PR TITLE
Adds support for URL templates

### DIFF
--- a/dataregistry-extension/tsconfig.json
+++ b/dataregistry-extension/tsconfig.json
@@ -11,7 +11,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2017",
+    "target": "es2019",
     "types": ["node"]
   },
   "include": ["src/*"],

--- a/dataregistry/package.json
+++ b/dataregistry/package.json
@@ -30,13 +30,15 @@
   },
   "dependencies": {
     "rxjs": "6.5.2",
-    "rxjs-spy": "7.5.1"
+    "rxjs-spy": "7.5.1",
+    "uri-templates": "0.2.0"
   },
   "devDependencies": {
     "@babel/core": "7.5.5",
     "@babel/preset-env": "7.5.5",
     "@types/jest": "24.0.13",
     "@types/node": "~8.0.47",
+    "@types/uri-templates": "0.1.30",
     "babel-jest": "24.9.0",
     "ix": "2.5.3",
     "jest": "24.8.0",

--- a/dataregistry/src/createConverter.ts
+++ b/dataregistry/src/createConverter.ts
@@ -1,0 +1,73 @@
+import { Observable } from "rxjs";
+import { MimeType_ } from "./datasets";
+import { MimeTypeDataType, DataType, INVALID } from "./datatypes";
+import { Converter } from "./converters";
+import { CachedObservable } from "./cachedObservable";
+import { DefaultTypedURL, TypedURL } from "./urltemplates";
+
+/**
+ * Create a a new converter, assuming:
+ *
+ * * returns either a single value or nothing
+ * * Cost is one more than the input
+ * * if it returns an observable, we should cache this observable
+ */
+export function createConverter<
+  fromD,
+  toD,
+  fromT = MimeType_,
+  toT = MimeType_,
+  urlT = URL
+>(
+  {
+    from = new MimeTypeDataType<fromD>() as any,
+    to = new MimeTypeDataType<toD>() as any,
+    url: urlT = new DefaultTypedURL() as any
+  }: {
+    from?: DataType<fromT, fromD>;
+    to?: DataType<toT, toD>;
+    url?: TypedURL<urlT>;
+  },
+  fn: (_: {
+    data: fromD;
+    url: urlT;
+    type: fromT;
+  }) =>
+    | null
+    | undefined
+    | (toT extends void ? toD : never)
+    | { data: toD; type: toT }
+    | Array<{ data: toD; type: toT }>
+): Converter<fromD, toD> {
+  return ({ url, mimeType, cost, data }) => {
+    const type = from.parseMimeType(mimeType);
+    if (type === INVALID) {
+      return [];
+    }
+    const urlArgs = urlT.parse(url);
+    if (urlArgs === null || urlArgs == undefined) {
+      return [];
+    }
+    const res = fn({ url: urlArgs, data, type });
+    if (!res) {
+      return [];
+    }
+    const arrayRes = isTypeData(res)
+      ? [res]
+      : Array.isArray(res)
+      ? res
+      : [{ type: (undefined as any) as toT, data: res }];
+    return arrayRes.map(({ data: newData, type: newType }) => ({
+      data:
+        newData instanceof Observable
+          ? ((CachedObservable.from(newData) as any) as toD)
+          : newData,
+      mimeType: to.createMimeType(newType),
+      cost: cost + 1
+    }));
+  };
+}
+
+export function isTypeData(o: unknown): o is { data: unknown; type: unknown } {
+  return o instanceof Object && "data" in o && "type" in o;
+}

--- a/dataregistry/src/datatypes.ts
+++ b/dataregistry/src/datatypes.ts
@@ -8,15 +8,8 @@
  */
 
 import { Converter } from "./converters";
-import {
-  MimeType_,
-  Dataset,
-  URL_,
-  createDatasets,
-  createDataset
-} from "./datasets";
-
-export const INVALID = Symbol("INVALID");
+import { MimeType_, Dataset } from "./datasets";
+import { DataType, INVALID } from "./createConverter";
 
 /**
  * TypedConverter gives you the Converter type between two types. If either is a TypedConverter,
@@ -33,44 +26,6 @@ export type TypedConverter<T, U> = T extends DataType<any, infer V>
   : U extends DataType<any, infer X>
   ? Converter<T, X>
   : Converter<T, U>;
-
-export abstract class DataType<T, U> {
-  abstract parseMimeType(mimeType: MimeType_): T | typeof INVALID;
-  abstract createMimeType(typeData: T): MimeType_;
-
-  createDataset(data: U, typeData: T) {
-    return createDataset(this.createMimeType(typeData), data);
-  }
-  createDatasets(url: URL_, data: U, typeData: T) {
-    return createDatasets(url, this.createMimeType(typeData), data);
-  }
-
-  /**
-   * Filer dataset for mimetypes of this type.
-   */
-  filterDataset(dataset: Dataset<any>): Map<T, U> {
-    const res = new Map<T, U>();
-    for (const [mimeType, [, data]] of dataset) {
-      const typeData_ = this.parseMimeType(mimeType);
-      if (typeData_ !== INVALID) {
-        res.set(typeData_, data as any);
-      }
-    }
-    return res;
-  }
-}
-
-/**
- * Dummy mime type data type, that accepts any mimetype.
- */
-export class MimeTypeDataType<T> extends DataType<MimeType_, T> {
-  parseMimeType(mimeType: MimeType_): MimeType_ | typeof INVALID {
-    return mimeType;
-  }
-  createMimeType(typeData: MimeType_): MimeType_ {
-    return typeData;
-  }
-}
 
 export class DataTypeNoArgs<T> extends DataType<void, T> {
   constructor(public mimeType: MimeType_) {

--- a/dataregistry/src/files.ts
+++ b/dataregistry/src/files.ts
@@ -7,11 +7,11 @@ import { URLDataType } from "./urls";
 import {
   DataTypeStringArg,
   TypedConverter,
-  createConverter
 } from "./datatypes";
 import { resolveMimetypeDataType } from "./resolvers";
 import { defer } from "rxjs";
 import { URL_ } from "./datasets";
+import { createConverter } from "./createConverter";
 
 export type FilePath = string;
 export const fileDataType = new DataTypeStringArg<FilePath>(

--- a/dataregistry/src/folders.ts
+++ b/dataregistry/src/folders.ts
@@ -1,10 +1,11 @@
-import { DataTypeNoArgs, TypedConverter, createConverter } from "./datatypes";
+import { DataTypeNoArgs, TypedConverter } from "./datatypes";
 import { nestedDataType } from "./nested";
 
 import { map } from "rxjs/operators";
 import { resolveDataType } from "./resolvers";
 import { Observable, defer } from "rxjs";
 import { join } from "path";
+import { createConverter } from "./createConverter";
 /**
  * A folder is a list paths in it as strings
  */

--- a/dataregistry/src/index.ts
+++ b/dataregistry/src/index.ts
@@ -18,3 +18,5 @@ export * from "./registry";
 export * from "./resolvers";
 export * from "./urls";
 export * from "./utils";
+export * from './createConverter';
+export * from './urltemplates';

--- a/dataregistry/src/nested.ts
+++ b/dataregistry/src/nested.ts
@@ -20,9 +20,10 @@
  */
 
 import { URL_ } from "./datasets";
-import { DataTypeNoArgs, createConverter } from "./datatypes";
+import { DataTypeNoArgs } from "./datatypes";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
+import { createConverter } from "./createConverter";
 
 /**
  * a list of relative URLs to resolve against the current URL.

--- a/dataregistry/src/resolvers.ts
+++ b/dataregistry/src/resolvers.ts
@@ -4,7 +4,6 @@ import {
   TypedConverter,
 } from "./datatypes";
 import { createConverter } from "./createConverter";
-import { Adjunction } from "./urltemplates";
 
 /**
  * Datasets without a known mimetype start as just a resolve mimetype and no data.

--- a/dataregistry/src/resolvers.ts
+++ b/dataregistry/src/resolvers.ts
@@ -2,8 +2,9 @@ import {
   DataTypeNoArgs,
   DataTypeStringArg,
   TypedConverter,
-  createConverter
 } from "./datatypes";
+import { createConverter } from "./createConverter";
+import { Adjunction } from "./urltemplates";
 
 /**
  * Datasets without a known mimetype start as just a resolve mimetype and no data.

--- a/dataregistry/src/urls.ts
+++ b/dataregistry/src/urls.ts
@@ -2,8 +2,9 @@ import { from, Observable, throwError, of } from "rxjs";
 import { fromFetch } from "rxjs/fetch";
 import { distinct, switchMap } from "rxjs/operators";
 import { URL_ } from "./datasets";
-import { DataTypeStringArg, createConverter } from "./datatypes";
+import { DataTypeStringArg } from "./datatypes";
 import { resolveMimetypeDataType } from "./resolvers";
+import { createConverter } from "./createConverter";
 
 /**
  * Type where data is a HTTP URL_ pointing to the data. It should be downloaded as a string and that

--- a/dataregistry/src/urltemplates.ts
+++ b/dataregistry/src/urltemplates.ts
@@ -1,0 +1,126 @@
+import * as uriTemplates from "uri-templates";
+
+import { URL_ } from "./datasets";
+
+export abstract class TypedURL<T> {
+  abstract parse(url: URL_): T | null | undefined;
+
+  abstract create(args: T): URL_;
+}
+
+export class DefaultTypedURL extends TypedURL<URL> {
+  parse(url: URL_) {
+    return new URL(url);
+  }
+
+  create(url: URL) {
+    return url.toString();
+  }
+}
+
+/**
+ * Type safe URL / URI Templates from RFC 6570
+ * 
+ * ```
+ * new URLTemplate('http://www.example.com/foo{?query,number}', {query: URLTemplate.string, number: URLTemplate.number})
+ * ```
+ */
+
+export class URLTemplate<T extends { [arg: string]: any }> extends TypedURL<T> {
+  /**
+   * Pass in the URL template as well an optional filter parameter that is called
+   * when parsing to further validate the args.
+   */
+  constructor(
+    private readonly template: string,
+    private readonly map: StringMapping<T>
+  ) {
+    super();
+    this._template = uriTemplates(template);
+  }
+
+  // These are some common types:
+
+  static get string(): Adjunction<string, string> {
+    return [s => s, s => s];
+  }
+
+  static get number(): Adjunction<string, number> {
+    return [
+      s => {
+        const n = Number(s);
+        return isNaN(n) ? null : n;
+      },
+      s => s.toString()
+    ];
+  }
+
+  static extension(extension: string): Adjunction<string, string> {
+    return [s => (s.endsWith(extension) ? s : null), s => s];
+  }
+
+  parse(url: URL_): T | null | undefined {
+    const args = (this._template.fromUri(url) as any) as
+      | {
+          [k in keyof T]: string;
+        }
+      | undefined;
+    if (!args) {
+      return null;
+    }
+    const newObject = Object.fromEntries(
+      Object.entries(args).map(([key, val]) => [key, this.map[key][0](val)])
+    );
+    // If none  of the value were none, return the object
+    if (nonNullableValues(newObject)) {
+      return newObject;
+    }
+  }
+
+  create(args: T): URL_ {
+    return this._template.fill(
+      Object.fromEntries(
+        Object.entries(args).map(([key, val]) => [key, this.map[key][1](val)])
+      )
+    );
+  }
+
+  /**
+   * Extends a URL template by adding another template on to the end.
+   */
+  extend<U extends { [arg: string]: any }>(
+    template: string,
+    map: StringMapping<U>
+  ): URLTemplate<T & U> {
+    return new URLTemplate(this.template + template, {
+      ...this.map,
+      ...map
+    } as any);
+  }
+
+  private readonly _template: uriTemplates.URITemplate;
+}
+
+/**
+ * Checks if an object has all non nullable values.
+ */
+function nonNullableValues<T extends { [k: string]: any }>(
+  t: T
+): t is { [K in keyof T]: NonNullable<T[K]> } {
+  return !Object.values(t).some(v => v === null || v === undefined);
+}
+
+/**
+ * Sort of like an Adjunction https://en.wikipedia.org/wiki/Adjoint_functors
+ * in that  you specify two functions, which  should be the inverse.
+ *
+ * However, it's a bit different since the first one is partial.
+ */
+export type Adjunction<T, V> = [
+  (args: T) => V | null | undefined,
+  (args: V) => T
+];
+
+type StringMapping<T extends { [key: string]: any }> = {
+  [K in keyof T]: Adjunction<string, T[K]>;
+};

--- a/dataregistry/src/urltemplates.ts
+++ b/dataregistry/src/urltemplates.ts
@@ -11,7 +11,6 @@ import { TypedURL } from "./createConverter";
  * new URLTemplate('http://www.example.com/foo{?query,number}', {query: URLTemplate.string, number: URLTemplate.number})
  * ```
  */
-
 export class URLTemplate<T extends { [arg: string]: any }> extends TypedURL<T> {
   /**
    * Creates a URL template, based on a string of a URL  template and a mapping of

--- a/dataregistry/src/urltemplates.ts
+++ b/dataregistry/src/urltemplates.ts
@@ -1,22 +1,8 @@
 import * as uriTemplates from "uri-templates";
 
 import { URL_ } from "./datasets";
+import { TypedURL } from "./createConverter";
 
-export abstract class TypedURL<T> {
-  abstract parse(url: URL_): T | null | undefined;
-
-  abstract create(args: T): URL_;
-}
-
-export class DefaultTypedURL extends TypedURL<URL> {
-  parse(url: URL_) {
-    return new URL(url);
-  }
-
-  create(url: URL) {
-    return url.toString();
-  }
-}
 
 /**
  * Type safe URL / URI Templates from RFC 6570

--- a/dataregistry/src/utils.ts
+++ b/dataregistry/src/utils.ts
@@ -1,4 +1,4 @@
-import { Observable, BehaviorSubject, Subscriber, Subscription } from "rxjs";
+import { Observable, BehaviorSubject } from "rxjs";
 import { tag } from "rxjs-spy/operators/tag";
 
 /**

--- a/dataregistry/tsconfig.json
+++ b/dataregistry/tsconfig.json
@@ -10,7 +10,7 @@
     "rootDir": "src",
     "sourceMap": true,
     "strict": true,
-    "target": "es2017",
+    "target": "es2019",
     "types": ["node", "jest"],
   },
   "include": ["src/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1042,6 +1042,29 @@
     react-dom "~16.8.4"
     sanitize-html "~1.20.1"
 
+"@jupyterlab/apputils@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/apputils/-/apputils-1.1.0.tgz#948243d9d226d6817605c5f425c1cac3e3fb803c"
+  integrity sha512-7pfHBDN+jYM065wa5jYvX+sSGEybXK7SwY9m1Sc31LA5Tz2pfhBbzW5BIF4MUzO8vHdu+OdAXWErS2h65WzeIQ==
+  dependencies:
+    "@jupyterlab/coreutils" "^3.1.0"
+    "@jupyterlab/services" "^4.1.0"
+    "@jupyterlab/ui-components" "^1.1.0"
+    "@phosphor/algorithm" "^1.1.3"
+    "@phosphor/commands" "^1.6.3"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/disposable" "^1.2.0"
+    "@phosphor/domutils" "^1.1.3"
+    "@phosphor/messaging" "^1.2.3"
+    "@phosphor/properties" "^1.1.3"
+    "@phosphor/signaling" "^1.2.3"
+    "@phosphor/virtualdom" "^1.1.3"
+    "@phosphor/widgets" "^1.8.0"
+    "@types/react" "~16.8.18"
+    react "~16.8.4"
+    react-dom "~16.8.4"
+    sanitize-html "~1.20.1"
+
 "@jupyterlab/attachments@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@jupyterlab/attachments/-/attachments-1.0.2.tgz#0c6d46043c861e76e9a94c1ecb9045eb452bf3f5"
@@ -1090,6 +1113,20 @@
     "@phosphor/signaling" "^1.2.3"
     "@phosphor/widgets" "^1.8.0"
 
+"@jupyterlab/codeeditor@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/codeeditor/-/codeeditor-1.1.0.tgz#893e5cb8a4b1c4f3cfb85f0a24635313cf0b9e0c"
+  integrity sha512-G22xSQajqJV0UxtaEkpRDsGAqumtkkpyjtN0yoqD/wlGentAllk1D1Sup99MBQKfZN+sBERbuUdLd0Oz5Q0e3g==
+  dependencies:
+    "@jupyterlab/coreutils" "^3.1.0"
+    "@jupyterlab/observables" "^2.3.0"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/disposable" "^1.2.0"
+    "@phosphor/dragdrop" "^1.3.3"
+    "@phosphor/messaging" "^1.2.3"
+    "@phosphor/signaling" "^1.2.3"
+    "@phosphor/widgets" "^1.8.0"
+
 "@jupyterlab/codemirror@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@jupyterlab/codemirror/-/codemirror-1.0.2.tgz#a72d23b881e9ee4a507ded17e23320d4fd05942b"
@@ -1109,10 +1146,46 @@
     codemirror "~5.47.0"
     react "~16.8.4"
 
+"@jupyterlab/codemirror@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/codemirror/-/codemirror-1.1.0.tgz#3597bf28a0e539f3821d758de65df17225efd389"
+  integrity sha512-/GWRUctUFVZlVGMoGZgsxcThEtlWulZqW2mm0u+OjWhMIqSE48mnEaELSWszR/oHpmoZH6RK2eD+fx/B8T+xJw==
+  dependencies:
+    "@jupyterlab/apputils" "^1.1.0"
+    "@jupyterlab/codeeditor" "^1.1.0"
+    "@jupyterlab/coreutils" "^3.1.0"
+    "@jupyterlab/observables" "^2.3.0"
+    "@jupyterlab/statusbar" "^1.1.0"
+    "@phosphor/algorithm" "^1.1.3"
+    "@phosphor/commands" "^1.6.3"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/disposable" "^1.2.0"
+    "@phosphor/signaling" "^1.2.3"
+    "@phosphor/widgets" "^1.8.0"
+    codemirror "~5.47.0"
+    react "~16.8.4"
+
 "@jupyterlab/coreutils@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/coreutils/-/coreutils-3.0.0.tgz#b636e2d478d7098ff12439de3cf4312edd945c09"
   integrity sha512-l48G1qhff4CZpsxjje92S6caLUixzfDMAD5vjNZL9obexUAMF+344cpVWsm2r2CQROUW7bPB8wjAtFbp8nK/QQ==
+  dependencies:
+    "@phosphor/commands" "^1.6.3"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/disposable" "^1.2.0"
+    "@phosphor/properties" "^1.1.3"
+    "@phosphor/signaling" "^1.2.3"
+    ajv "^6.5.5"
+    json5 "^2.1.0"
+    minimist "~1.2.0"
+    moment "^2.24.0"
+    path-posix "~1.0.0"
+    url-parse "~1.4.3"
+
+"@jupyterlab/coreutils@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz#b307569462c468d6a09dfa06f32fed03e55dd811"
+  integrity sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==
   dependencies:
     "@phosphor/commands" "^1.6.3"
     "@phosphor/coreutils" "^1.3.1"
@@ -1161,7 +1234,7 @@
     "@phosphor/widgets" "^1.8.0"
     react "~16.8.4"
 
-"@jupyterlab/docregistry@^1.0.0", "@jupyterlab/docregistry@^1.0.2":
+"@jupyterlab/docregistry@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@jupyterlab/docregistry/-/docregistry-1.0.2.tgz#fbaeaf16dbae2740a7059a8adf056cbb362c8832"
   integrity sha512-d6Z2IOe+48NheTpve2pAI6PfKN8VDx/NChhGE5V0YdQTHyNFea8GMRF9wHyP1o5NPuj3fx00gP73O6gfAwzqoA==
@@ -1174,6 +1247,26 @@
     "@jupyterlab/rendermime" "^1.0.2"
     "@jupyterlab/rendermime-interfaces" "^1.3.0"
     "@jupyterlab/services" "^4.0.2"
+    "@phosphor/algorithm" "^1.1.3"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/disposable" "^1.2.0"
+    "@phosphor/messaging" "^1.2.3"
+    "@phosphor/signaling" "^1.2.3"
+    "@phosphor/widgets" "^1.8.0"
+
+"@jupyterlab/docregistry@^1.0.4":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/docregistry/-/docregistry-1.1.0.tgz#21c262282c8624afbbe12f536c24b79c97964aee"
+  integrity sha512-Ryv4kiFZzq2Ep/66cg1kreq+VGk3tIO3ThZLOxKOADaqd7rEbWXXso3OeGQVCwGpRE5sejNmYDeMT4tiTqF/aA==
+  dependencies:
+    "@jupyterlab/apputils" "^1.1.0"
+    "@jupyterlab/codeeditor" "^1.1.0"
+    "@jupyterlab/codemirror" "^1.1.0"
+    "@jupyterlab/coreutils" "^3.1.0"
+    "@jupyterlab/observables" "^2.3.0"
+    "@jupyterlab/rendermime" "^1.1.0"
+    "@jupyterlab/rendermime-interfaces" "^1.4.0"
+    "@jupyterlab/services" "^4.1.0"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/disposable" "^1.2.0"
@@ -1239,6 +1332,17 @@
     "@phosphor/messaging" "^1.2.3"
     "@phosphor/signaling" "^1.2.3"
 
+"@jupyterlab/observables@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/observables/-/observables-2.3.0.tgz#db58eee4c874920d5099ccdbe7dc85a9d278782b"
+  integrity sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==
+  dependencies:
+    "@phosphor/algorithm" "^1.1.3"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/disposable" "^1.2.0"
+    "@phosphor/messaging" "^1.2.3"
+    "@phosphor/signaling" "^1.2.3"
+
 "@jupyterlab/outputarea@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@jupyterlab/outputarea/-/outputarea-1.0.2.tgz#8489c88670e0bcbf3ac1680206407c4f005aedad"
@@ -1266,6 +1370,14 @@
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/widgets" "^1.8.0"
 
+"@jupyterlab/rendermime-interfaces@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.4.0.tgz#2683c1f8eb1c4da833a40ae551d093379c403d06"
+  integrity sha512-6GtbudtK7Yl37ldnQUQ6hTUDzjVgemiDXokEdsSTLPOPoPwKw3gaEBfxrOz/LBITfqIfbpuBzYU8lQ4rHq0TfQ==
+  dependencies:
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/widgets" "^1.8.0"
+
 "@jupyterlab/rendermime@^1.0.0", "@jupyterlab/rendermime@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime/-/rendermime-1.0.2.tgz#3290ac71c716beb1a6de346a7f25d5712870a58f"
@@ -1285,6 +1397,25 @@
     lodash.escape "^4.0.1"
     marked "0.6.2"
 
+"@jupyterlab/rendermime@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime/-/rendermime-1.1.0.tgz#e2b944bbe187f15228b0a17d0c59affbf2ea3a61"
+  integrity sha512-fkCbvbE+L8gYLTJsCXDeDusBGE00DYF5gbIw1eryX7PwEhv7WLHihVy/H8wX6Mh3UKB19Y87EhRdEJpEo9GJZA==
+  dependencies:
+    "@jupyterlab/apputils" "^1.1.0"
+    "@jupyterlab/codemirror" "^1.1.0"
+    "@jupyterlab/coreutils" "^3.1.0"
+    "@jupyterlab/observables" "^2.3.0"
+    "@jupyterlab/rendermime-interfaces" "^1.4.0"
+    "@jupyterlab/services" "^4.1.0"
+    "@phosphor/algorithm" "^1.1.3"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/messaging" "^1.2.3"
+    "@phosphor/signaling" "^1.2.3"
+    "@phosphor/widgets" "^1.8.0"
+    lodash.escape "^4.0.1"
+    marked "0.6.2"
+
 "@jupyterlab/services@^4.0.2":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@jupyterlab/services/-/services-4.0.2.tgz#88561f5ef6099bf8462efc1402541738a8b11f23"
@@ -1292,6 +1423,20 @@
   dependencies:
     "@jupyterlab/coreutils" "^3.0.0"
     "@jupyterlab/observables" "^2.2.0"
+    "@phosphor/algorithm" "^1.1.3"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/disposable" "^1.2.0"
+    "@phosphor/signaling" "^1.2.3"
+    node-fetch "^2.6.0"
+    ws "^7.0.0"
+
+"@jupyterlab/services@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/services/-/services-4.1.0.tgz#bb61179e656755144789e0f54a02175a0dce5b96"
+  integrity sha512-5C53UdpLP5rLLpN8zEfzole5PNakNWSDCitd4ysqZiWihV4lpNNXKmqn5seHrcvevUkrDM9pyNcg00djGkpbvw==
+  dependencies:
+    "@jupyterlab/coreutils" "^3.1.0"
+    "@jupyterlab/observables" "^2.3.0"
     "@phosphor/algorithm" "^1.1.3"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/disposable" "^1.2.0"
@@ -1317,6 +1462,25 @@
     react "~16.8.4"
     typestyle "^2.0.1"
 
+"@jupyterlab/statusbar@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/statusbar/-/statusbar-1.1.0.tgz#ce2720b23bda5da89c0317356e5d48cd5bd827a4"
+  integrity sha512-PtspGJIb2zS0ikTd+wnlNJBw5WHvr3h1rVPCfpu348wZ7I480X1yBjfmcIXt/dsaWM4YSrd/xAvZbiQdMXukrA==
+  dependencies:
+    "@jupyterlab/apputils" "^1.1.0"
+    "@jupyterlab/codeeditor" "^1.1.0"
+    "@jupyterlab/coreutils" "^3.1.0"
+    "@jupyterlab/services" "^4.1.0"
+    "@jupyterlab/ui-components" "^1.1.0"
+    "@phosphor/algorithm" "^1.1.3"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/disposable" "^1.2.0"
+    "@phosphor/messaging" "^1.2.3"
+    "@phosphor/signaling" "^1.2.3"
+    "@phosphor/widgets" "^1.8.0"
+    react "~16.8.4"
+    typestyle "^2.0.1"
+
 "@jupyterlab/ui-components@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/ui-components/-/ui-components-1.0.0.tgz#f82b00a68a24434ae56bee01d951aa4e087bb687"
@@ -1326,6 +1490,21 @@
     "@blueprintjs/icons" "^3.3.0"
     "@blueprintjs/select" "^3.3.0"
     react "~16.8.4"
+
+"@jupyterlab/ui-components@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/ui-components/-/ui-components-1.1.0.tgz#706e4fa189960781db4cfa09f6c5ffd91942e0a7"
+  integrity sha512-+P8Fs6EuNZro0vEEeqqlXtLg46QHZGRjx8mucw7SHGTEsCE36a9NLJkvHV2kib7ulftf01sUO4IFisjUemlvtA==
+  dependencies:
+    "@blueprintjs/core" "^3.9.0"
+    "@blueprintjs/select" "^3.3.0"
+    "@jupyterlab/coreutils" "^3.1.0"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/messaging" "^1.2.3"
+    "@phosphor/virtualdom" "^1.1.3"
+    "@phosphor/widgets" "^1.8.0"
+    react "~16.8.4"
+    typestyle "^2.0.1"
 
 "@mapbox/polylabel@1":
   version "1.0.2"
@@ -1601,6 +1780,11 @@
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@types/stacktrace-js/-/stacktrace-js-0.0.32.tgz#d23e4a36a5073d39487fbea8234cc6186862d389"
   integrity sha512-SdxmlrHfO0BxgbBP9HZWMUo2rima8lwMjPiWm6S0dyKkDa5CseamktFhXg8umu3TPVBkSlX6ZoB5uUDJK89yvg==
+
+"@types/uri-templates@0.1.30":
+  version "0.1.30"
+  resolved "https://registry.yarnpkg.com/@types/uri-templates/-/uri-templates-0.1.30.tgz#06ce7ff472b9bc3cf5036e08ed916c68cc085765"
+  integrity sha512-tD55i9vfenTtWY2sYejAHU/srlqFp0ofRmxvrvvq9vjteTEsdKkDxMOeTfsvWIFt8267szAzw5yQgYIzq2DsTg==
 
 "@types/yargs-parser@*":
   version "13.0.0"
@@ -6562,6 +6746,11 @@ uri-js@^4.2.2:
   integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
+
+uri-templates@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/uri-templates/-/uri-templates-0.2.0.tgz#2b5784511cc909868731e9233c268097d10b499f"
+  integrity sha1-K1eEURzJCYaHMekjPCaAl9ELSZ8=
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This closes https://github.com/jupyterlab/jupyterlab-data-explorer/issues/64 by adding support for URL  templates.  So far, we only use this  in the  `notebook.ts` file to encode  the different notebook URLs.