### PR TITLE
Update styles to use JL CSS variables

### DIFF
--- a/dataregistry-extension/style.css
+++ b/dataregistry-extension/style.css
@@ -44,9 +44,8 @@
  */
 
 .jl-explorer {
-  background: #fff;
-  color: #000;
-  font-family: Helvetica, sans-serif;
+  background-color: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color1);
   height: 100%;
   display: flex;
   flex-direction: column;
@@ -56,9 +55,9 @@
   overflow: auto;
 }
 .jl-explorer-button {
-  color: #2196f3;
+  color: var(--jp-brand-color1);
+  background: var(--jp-layout-color1);
   border-radius: 2px;
-  background: #fff;
   font-size: 10px;
   border-width: 0;
   margin-right: 12px; /* 2 + 10 spacer between */
@@ -66,36 +65,34 @@
 }
 
 .jl-explorer-button:active {
-  background: #bdbdbd;
+  background: var(--jp-border-color1);
 }
 .jl-explorer-button:hover {
-  background: #e0e0e0;
+  background-color: var(--jp-border-color2);
 }
 
 .jl-explorer-button:active:hover {
-  background: #bdbdbd;
+  background: var(--jp-border-color1);
 }
 
 .jl-explorer-dataset {
-  border-bottom: 1px solid #e0e0e0;
-  color: #333;
   padding: 4px;
   padding-right: 12px;
   padding-left: 12px;
   border-left-width: 8px;
-  border-left-color: white;
+  border-left-color: var(--jp-layout-color1);
   border-left-style: solid;
 }
 
 .jl-explorer-dataset:hover {
-  border-left-color: #e0e0e0;
+  border-left-color: var(--jp-border-color2);
 }
 .jl-explorer-dataset:active {
-  border-left-color: #bdbdbd;
+  border-left-color: var(--jp-border-color1);
 }
 
 .jl-explorer-dataset:active:hover {
-  border-left-color: #bdbdbd;
+  border-left-color: var(--jp-border-color1);
 }
 
 .jl-explorer-active-dataset {
@@ -115,7 +112,7 @@
 }
 
 .jl-explorer-dataset-name {
-  font-size: 12px;
+  font-size: var(--jp-ui-font-size0);
   font-weight: unset;
   margin: unset;
   overflow: hidden;
@@ -128,10 +125,10 @@
   padding-bottom: 6px;
   padding-left: 12px;
   padding-right: 12px;
-  font-size: 14px;
+  font-size: var(--jp-ui-font-size1);
+  color: var(--jp-ui-font-color0);
   letter-spacing: 0.1em;
   margin: unset;
-  color: #333;
   display: flex;
   justify-content: space-between;
   border-bottom: var(--jp-border-width) solid var(--jp-toolbar-border-color);

--- a/dataregistry-extension/style.css
+++ b/dataregistry-extension/style.css
@@ -87,6 +87,17 @@
   border-left-style: solid;
 }
 
+.jl-explorer-dataset:hover {
+  border-left-color: #e0e0e0;
+}
+.jl-explorer-dataset:active {
+  border-left-color: #bdbdbd;
+}
+
+.jl-explorer-dataset:active:hover {
+  border-left-color: #bdbdbd;
+}
+
 .jl-explorer-active-dataset {
   border-left-color: var(--jp-brand-color1);
 }

--- a/dataregistry-extension/style.css
+++ b/dataregistry-extension/style.css
@@ -25,6 +25,10 @@
   height: 100%;
   display: flex;
   flex-flow: column;
+  padding: 4px;
+  color: var(--jp-ui-font-color1);
+  background-color: var(--jp-layout-color1);
+  font-size: var(--jp-ui-font-size1);
 }
 
 .jl-dr-browser-url {

--- a/dataregistry/src/cachedObservable.ts
+++ b/dataregistry/src/cachedObservable.ts
@@ -100,24 +100,31 @@ export class CachedObservable<T> extends Observable<T> {
           });
           const subscription = from.subscribe(this.observer);
           const newState = this.state.value;
-          if (newState.state === State.waitingFirst) {
-            this.state.next({
-              ...newState,
-              state: State.waitingFirstSubs,
-              subscription
-            });
-          } else if (newState.state === State.waitingNext) {
-            this.state.next({
-              ...newState,
-              state: State.waitingNextSubs,
-              subscription
-            });
-          } else {
-            throw new Error(
-              `Cannot be in state ${newState.state} after subscribing`
-            );
+          switch (newState.state) {
+            case State.waitingFirst:
+              this.state.next({
+                ...newState,
+                state: State.waitingFirstSubs,
+                subscription
+              });
+              break;
+            case State.waitingNext:
+              this.state.next({
+                ...newState,
+                state: State.waitingNextSubs,
+                subscription
+              });
+              break;
+            // If we run the subscription and it complete or errors
+            // already, then we are done.
+            case State.complete:
+            case State.error:
+              break;
+            default:
+              throw new Error(
+                `Cannot be in state ${newState.state} after subscribing`
+              );
           }
-
           break;
         case State.waitingFirst:
         case State.waitingFirstSubs:


### PR DESCRIPTION
This updates the explorer and browser to use JL css variables, so that they render correctly in light and dark themes. The dropdowns in the browser are still white in the dark theme, but I think we can tackle this later. I didn't see any existing JL dropdown I could copy the styles from. 


After:

<img width="1920" alt="Screen Shot 2019-10-03 at 11 22 31 AM" src="https://user-images.githubusercontent.com/1186124/66140528-48de5780-e5d0-11e9-843d-8b415d1e3a4b.png">
<img width="1920" alt="Screen Shot 2019-10-03 at 11 22 22 AM" src="https://user-images.githubusercontent.com/1186124/66140537-4aa81b00-e5d0-11e9-99cf-93eaf42cb600.png">
