### PR TITLE
Remove obsolete Docker ignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-node_modules


### PR DESCRIPTION
This PR simply removes what appears to be an obsolete Docker ignore file. The file was added in this [commit](https://github.com/jupyterlab/jupyterlab-data-explorer/commit/540408ef9f711dbaa441d837e2bf028c30eda083) when local development practices involved Docker.