### PR TITLE
Fix missing command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:dev": "jlpm install && jlpm run clean:packages && lerna link && jlpm run build:packages && jlpm run link:packages && jupyter labextension list",
     "build:jupyter": "(jupyter lab build || (jlpm run build:jupyter:remediate && jupyter lab build)) && jupyter lab",
     "build:jupyter:remediate": "curr_dir=$PWD && (cd $(jupyter lab path | head -n1 | sed s/Application\\ directory:\\ *//)/staging && echo $PWD && echo '\"@jupyterlab:registry\" \"http://localhost:4873\"' >> .yarnrc && cat .yarnrc && YARN_REGISTRY=http://localhost:4873 node ./yarn.js install --non-interactive && cd $curr_dir) || cd $curr_dir",
-    "build:jupyter:watch": "jlpm run build:jupyter && jupyter lab --watch",
+    "build:jupyter:watch": "(jupyter lab build || (jlpm run build:jupyter:remediate && jupyter lab build)) && jupyter lab --watch",
     "build:packages": "lerna run build",
     "build:watch": "tsc --build --watch --listEmittedFiles packages/*",
     "clean": "jlpm run clean:jupyter && jlpm clean:packages && jlpm clean:node",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "all:watch": "jlpm run clean && jlpm run build && jlpm run build:jupyter:watch",
     "build": "jlpm run build:dev",
     "build:dev": "jlpm install && jlpm run clean:packages && lerna link && jlpm run build:packages && jlpm run link:packages && jupyter labextension list",
-    "build:jupyter": "jupyter lab build || (jlpm run build:jupyter:remediate && jupyter lab build)",
+    "build:jupyter": "(jupyter lab build || (jlpm run build:jupyter:remediate && jupyter lab build)) && jupyter lab",
     "build:jupyter:remediate": "curr_dir=$PWD && (cd $(jupyter lab path | head -n1 | sed s/Application\\ directory:\\ *//)/staging && echo $PWD && echo '\"@jupyterlab:registry\" \"http://localhost:4873\"' >> .yarnrc && cat .yarnrc && YARN_REGISTRY=http://localhost:4873 node ./yarn.js install --non-interactive && cd $curr_dir) || cd $curr_dir",
     "build:jupyter:watch": "jlpm run build:jupyter && jupyter lab --watch",
     "build:packages": "lerna run build",


### PR DESCRIPTION
This PR adds a missing command to ensure behavior as stated in the dev docs: namely, that assets are both built and lab launched.

This change ensures behavior is consistent with `jlpm run build:jupyter:watch`, which also launches lab.