### PR TITLE
This fixes the local build

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "clean:jupyter": "jlpm run uninstall:extensions && (lerna run --no-bail unlink || echo 'At least one unlink command failed, but continuing...') && jupyter lab clean",
     "clean:node": "lerna clean --yes && rimraf node_modules",
     "clean:packages": "lerna run clean",
-    "link:packages": "lerna run link",
+    "link:packages": "jupyter labextension link ./packages/* --no-build",
     "lint": "jlpm run lint:css && jlpm run lint:typescript",
     "lint:check": "jlpm run prettier:check && jlpm run lint:typescript:check",
     "lint:css": "stylelint packages/**/*.css",

--- a/packages/dataregistry-csvviewer-extension/package.json
+++ b/packages/dataregistry-csvviewer-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/dataregistry-csvviewer-extension",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "CSV viewer data converter.",
   "keywords": [
     "jupyter",
@@ -37,7 +37,7 @@
     "@jupyterlab/application": "^1.0.0",
     "@jupyterlab/csvviewer": "^1.0.0",
     "@jupyterlab/dataregistry": "^3.0.0",
-    "@jupyterlab/dataregistry-registry-extension": "0.0.0",
+    "@jupyterlab/dataregistry-registry-extension": "^1.0.0",
     "@phosphor/datagrid": "^0.1.10",
     "@phosphor/messaging": "^1.2.3",
     "rxjs": "^6.5.2"

--- a/packages/dataregistry-extension/package.json
+++ b/packages/dataregistry-extension/package.json
@@ -42,7 +42,7 @@
     "@jupyterlab/coreutils": "^3.0.0",
     "@jupyterlab/csvviewer": "^1.0.0",
     "@jupyterlab/dataregistry": "^3.0.0",
-    "@jupyterlab/dataregistry-registry-extension": "0.0.0",
+    "@jupyterlab/dataregistry-registry-extension": "^1.0.0",
     "@jupyterlab/docmanager": "^1.0.0",
     "@jupyterlab/docregistry": "^1.0.4",
     "@jupyterlab/filebrowser": "^1.0.0",

--- a/packages/dataregistry-registry-extension/package.json
+++ b/packages/dataregistry-registry-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/dataregistry-registry-extension",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Registry.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
* Links all packages at once, so they are properly de-duplicated by yarn
* Bumps versions up to 1.0.0. For some reason at 0.0.0 they were
not being de-duplicated

This works for me locally now. @kgryte does it work for you?